### PR TITLE
random generator fix, for loop indexing, apply STL

### DIFF
--- a/C++/p004-Layers-and-Object.cpp
+++ b/C++/p004-Layers-and-Object.cpp
@@ -1,36 +1,30 @@
 /**
- * Creates a dense layer 
- * 
+ * Creates a dense layer
+ *
  * Associated tutorial https://www.youtube.com/watch?v=TEWy9vZcxW4
  */
 #include <iostream>
 #include <random>
 #include <vector>
+#include <algorithm>
+#include <functional>
+
 using namespace std;
 
-/* A helper function to get a random float in range [low, high] */
-double getRandomDouble(double low, double high) {
-	random_device rd;  
-    mt19937 gen(rd()); 
-    uniform_real_distribution<> dis(low, high);
-    return dis(gen);
-}
 
 /* A dot product function */
-vector<vector<double>> dotProduct(vector<vector<double>> inputs, vector<vector<double>> weights) {
-	// If the inputs is of size (a, b) and weights is of size (b, c) then outputs is of size (a, c)
-	vector<vector<double>> outputs = vector<vector<double>>(inputs.size(), vector<double>(weights[0].size()));
-
+vector<vector<double>> dotProduct(vector<vector<double>> inputs,
+                                  vector<vector<double>> weights) {
+	// If the inputs is of size (a, b) and weights is of size (b, c)
+	// then outputs is of size (a, c)
+	vector<vector<double>> outputs = vector<vector<double>>(inputs.size(), \
+                        vector<double>(weights[0].size(), 0.0));
 	// Calculating the dot product
-	for(int i = 0; i < inputs.size(); i++) {
-		for(int j = 0; j < weights[0].size(); j++) {
-			double output = 0;
-			for(int k = 0; k < inputs[0].size(); k++) {
-				output += inputs[i][k] * weights[k][j];
-			}
-			outputs[i][j] = output;
-		}
-	}
+
+	for (int i = 0; i < inputs.size(); i++)
+		for (int j = 0; j < weights[0].size(); j++)
+			for (int k = 0; k < inputs[0].size(); k++)
+				outputs[i][j] += inputs[i][k] * weights[k][j];
 
 	return outputs;
 }
@@ -38,12 +32,20 @@ vector<vector<double>> dotProduct(vector<vector<double>> inputs, vector<vector<d
 /* A function to add two vectors */
 vector<double> add(vector<double> vector1, vector<double> vector2) {
 	vector<double> output(vector1.size());
-
-	for(int i = 0; i < vector1.size(); i++) {
-		output[i] = vector1[i] + vector2[i];
-	}
+	// add two vectors element-wise using STL
+    transform(vector1.begin(), vector1.end(), vector2.begin(),
+                   output.begin(), plus<double>());
 
 	return output;
+}
+
+// keep generator global to get different number in each call
+std::random_device rd;
+std::mt19937 gen(rd());
+/* A helper function to get a random float in range [low, high] */
+double getRandomDouble(double low, double high) {
+        uniform_real_distribution<double> dis(low, high);
+        return dis(gen);
 }
 
 /* The dense layer class */
@@ -56,33 +58,25 @@ private:
 public:
 	/* Constructor */
 	DenseLayer(int n_inputs, int n_neurons) {
-		weights = vector<vector<double>>(n_inputs, vector<double>(n_neurons));
-		for(int i = 0; i < n_inputs; i++) {
-			for(int j = 0; j < n_neurons; j++) {
-				/* random weights initialization */
-				weights[i][j] = 0.1 * getRandomDouble(-1, 1);
-			}
-		}
-
-		// Initializing biases as a vector of zeros
+		weights = vector<vector<double>>(n_inputs, \
+                vector<double>(n_neurons, 0.1 * getRandomDouble(-1, 1)));
 		biases = vector<double>(n_neurons, 0);
 	}
 
 	/* forward pass */
 	void forward(vector<vector<double>> inputs) {
 		output = dotProduct(inputs, weights);
-		for(int i = 0; i < output.size(); i++) {
-			output[i] = add(output[i], biases);
-		}
+        for (auto& out: output)
+            out = add(out, biases);
 	}
 
 	void printOutput() {
-		for(int i = 0; i < output.size(); i++) {
-			for(int j = 0; j < output[0].size(); j++) {
-				cout << output[i][j] << " ";
-			}
-			cout << endl;
-		}
+	    for (auto row: output) {
+            for (auto col: row)
+                cout << col << " ";
+
+            cout << "\n";
+	    }
 	}
 
 	/* Getter for the output variable which is private */
@@ -92,22 +86,22 @@ public:
 };
 
 int main() {
-	/* Initializing two layers*/ 
+	/* Initializing two layers*/
 	DenseLayer l1(4, 5);
 	DenseLayer l2(5, 2);
 
 	/* Sample input */
 	vector<vector<double>> X = {
-		{1, 2, 3, 2.5},
-     	{2.0, 5.0, -1.0, 2.0},
-     	{-1.5, 2.7, 3.3, -0.8}
+		{   1,   2,    3, 2.5},
+		{ 2.0, 5.0, -1.0, 2.0},
+		{-1.5, 2.7, 3.3, -0.8},
  	};
 
- 	cout << "First layer forward pass output:" << endl;
+ 	cout << "First layer forward pass output:" << '\n';
  	l1.forward(X);
  	l1.printOutput();
 
- 	cout << endl << "Second layer forward pass output:" << endl;
+ 	cout << '\n' << "Second layer forward pass output:" << '\n';
  	l2.forward(l1.getOutput());
  	l2.printOutput();
 }


### PR DESCRIPTION
By making gen global variable:
std::random_device rd;
std::mt19937 gen(rd());
we make sure that the generator produces different numbers in each call of the function getRandomDouble.

STL is used to avoid for loops. Explicit indexing avoided when not necessary.
Avoiding std::endl is recommended. Vector in initialized where possible.